### PR TITLE
fix: changed filePath.split from path.sep to '/'

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -85,7 +85,7 @@ const factory = {
    * @returns {Array.<?string>} List of directories
    */
   getPathTree(filePath) {
-    const splitPath = filePath.split(path.sep);
+    const splitPath = filePath.split('/');
     splitPath.pop();
 
     return splitPath;


### PR DESCRIPTION
Solved an issue on Windows. 

node-glob always returns a path with forward slashes ('/') on windows (https://github.com/isaacs/node-glob#windows) and was causing a mismatch of expectations with using path.sep on win32 (Which returns '\').